### PR TITLE
[feat] 🐯 소비 목표 등록, 소비 목표 조회 API 수정

### DIFF
--- a/src/main/java/com/example/PayAll_BE/controller/LimitController.java
+++ b/src/main/java/com/example/PayAll_BE/controller/LimitController.java
@@ -17,10 +17,11 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/limit")
+@RequestMapping("/api/limit")
 public class LimitController {
 	private final LimitService limitService;
 
+	// 소비목표 등록
 	@PostMapping
 	public ResponseEntity<ApiResult> registerLimit(
 		@RequestParam Long userId,
@@ -32,6 +33,7 @@ public class LimitController {
 		);
 	}
 
+	// 소비목표 조회
 	@GetMapping
 	public ResponseEntity<ApiResult> getLimit(
 		@RequestParam Long userId

--- a/src/main/java/com/example/PayAll_BE/controller/UserController.java
+++ b/src/main/java/com/example/PayAll_BE/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.example.PayAll_BE.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.PayAll_BE.dto.ApiResult;
+import com.example.PayAll_BE.dto.UserResponseDto;
+import com.example.PayAll_BE.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+	private final UserService userService;
+
+	@GetMapping
+	public ResponseEntity<ApiResult> getUserInfo(
+		@RequestParam Long userId
+	) {
+		UserResponseDto userInfo = userService.getUserInfo(userId);
+		return ResponseEntity.ok(
+			new ApiResult(200, "OK", "사용자 정보 조회 성공", userInfo)
+		);
+	}
+}

--- a/src/main/java/com/example/PayAll_BE/dto/Limit/LimitRequestDto.java
+++ b/src/main/java/com/example/PayAll_BE/dto/Limit/LimitRequestDto.java
@@ -8,6 +8,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LimitRequestDto {
-	private long averageSpent; // 지난 3개월 평균 지출 금액
 	private long limitPrice;
 }

--- a/src/main/java/com/example/PayAll_BE/dto/Limit/LimitResponseDto.java
+++ b/src/main/java/com/example/PayAll_BE/dto/Limit/LimitResponseDto.java
@@ -16,4 +16,6 @@ public class LimitResponseDto {
 	private Long userId;
 	private long limitPrice;
 	private LocalDateTime limitDate; // 소비 목표 설정 날짜
+	private long averageSpent; // 지난 3개월 평균 소비 금액
+	private Long lastMonthLimit; // 지난달 소비 목표 금액
 }

--- a/src/main/java/com/example/PayAll_BE/dto/Statistics/StatisticsResponseDto.java
+++ b/src/main/java/com/example/PayAll_BE/dto/Statistics/StatisticsResponseDto.java
@@ -12,9 +12,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class StatisticsResponseDto {
+	private String name; // 사용자 이름 추가
 	private String date;
-	private long totalSpent; // 총 지출
-	private long dateAverage; // 하루 평균 지출
+	private long totalSpent;
+	private long dateAverage;
 	private long difference; // 전월 대비 차이
 	private List<CategoryExpense> categoryExpenses; // 카테고리별 지출
 	private List<FixedExpense> fixedExpenses; // 고정 지출

--- a/src/main/java/com/example/PayAll_BE/dto/UserResponseDto.java
+++ b/src/main/java/com/example/PayAll_BE/dto/UserResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.PayAll_BE.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserResponseDto {
+	private String name;
+	private String authId;
+	private String phone;
+	private String address;
+}

--- a/src/main/java/com/example/PayAll_BE/repository/LimitRepository.java
+++ b/src/main/java/com/example/PayAll_BE/repository/LimitRepository.java
@@ -1,5 +1,6 @@
 package com.example.PayAll_BE.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,8 @@ import com.example.PayAll_BE.entity.Limit;
 public interface LimitRepository extends JpaRepository<Limit, Long> {
 
 	Optional<Limit> findTopByUser_IdOrderByLimitDateDesc(Long userId);
+
+	Optional<Limit> findFirstByUserIdAndLimitDateBetweenOrderByLimitDateDesc(
+		Long userId, LocalDateTime startDate, LocalDateTime endDate
+	);
 }

--- a/src/main/java/com/example/PayAll_BE/service/LimitService.java
+++ b/src/main/java/com/example/PayAll_BE/service/LimitService.java
@@ -1,15 +1,18 @@
 package com.example.PayAll_BE.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 
 import com.example.PayAll_BE.dto.Limit.LimitRequestDto;
 import com.example.PayAll_BE.dto.Limit.LimitResponseDto;
 import com.example.PayAll_BE.entity.Limit;
+import com.example.PayAll_BE.entity.Statistics;
 import com.example.PayAll_BE.entity.User;
 import com.example.PayAll_BE.exception.NotFoundException;
 import com.example.PayAll_BE.repository.LimitRepository;
+import com.example.PayAll_BE.repository.StatisticsRepository;
 import com.example.PayAll_BE.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,16 +22,19 @@ import lombok.RequiredArgsConstructor;
 public class LimitService {
 	private final LimitRepository limitRepository;
 	private final UserRepository userRepository;
+	private final StatisticsRepository statisticsRepository;
 
 	public LimitResponseDto registerLimit(Long userId, LimitRequestDto limitRequestDto) {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException("해당 유저를 찾을 수 없습니다."));
 
-		long limitPrice = limitRequestDto.getLimitPrice();
+		LocalDateTime threeMonthsAgo = LocalDateTime.now().minusMonths(3);
+		LocalDateTime now = LocalDateTime.now();
+		long averageSpent = calculateAverageSpent(userId, threeMonthsAgo, now);
 
 		Limit limit = Limit.builder()
 			.user(user)
-			.limitPrice(limitPrice)
+			.limitPrice(limitRequestDto.getLimitPrice())
 			.limitDate(LocalDateTime.now())
 			.build();
 
@@ -39,6 +45,7 @@ public class LimitService {
 			.userId(userId)
 			.limitPrice(savedLimit.getLimitPrice())
 			.limitDate(savedLimit.getLimitDate())
+			.averageSpent(averageSpent)
 			.build();
 	}
 
@@ -47,11 +54,45 @@ public class LimitService {
 		Limit limit = limitRepository.findTopByUser_IdOrderByLimitDateDesc(userId)
 			.orElseThrow(() -> new IllegalArgumentException("소비 목표가 존재하지 않습니다."));
 
+		// 지난 3개월 평균 지출 계산
+		LocalDateTime threeMonthsAgo = LocalDateTime.now().minusMonths(3);
+		LocalDateTime now = LocalDateTime.now();
+		long averageSpent = calculateAverageSpent(userId, threeMonthsAgo, now);
+
+		// 지난달 계산
+		int lastMonth = now.minusMonths(1).getMonthValue();
+		int lastMonthYear = now.minusMonths(1).getYear();
+
+		// 지난달 소비 목표 조회
+		Limit lastMonthLimit = limitRepository.findFirstByUserIdAndLimitDateBetweenOrderByLimitDateDesc(
+			userId,
+			LocalDateTime.of(lastMonthYear, lastMonth, 1, 0, 0),
+			LocalDateTime.of(lastMonthYear, lastMonth, 1, 0, 0).plusMonths(1).minusSeconds(1)
+		).orElse(null);
+
+		Long lastMonthLimitPrice = lastMonthLimit != null ? lastMonthLimit.getLimitPrice() : null;
+
 		return LimitResponseDto.builder()
 			.limitId(limit.getLimitId())
 			.userId(limit.getUser().getId())
 			.limitPrice(limit.getLimitPrice())
 			.limitDate(limit.getLimitDate())
+			.averageSpent(averageSpent) // 평균 지출 추가
+			.lastMonthLimit(lastMonthLimitPrice) // 지난달 소비 목표 금액
 			.build();
+	}
+
+	// 지난 3개월간 평균 지출 계산 메소드
+	private long calculateAverageSpent(Long userId, LocalDateTime fromDate, LocalDateTime toDate) {
+		List<Statistics> lastThreeMonthsStats = statisticsRepository.findByUserIdAndStatisticsDateBetween(
+			userId, fromDate, toDate
+		);
+
+		long totalSpent = lastThreeMonthsStats.stream()
+			.mapToLong(Statistics::getStatisticsAmount)
+			.sum();
+
+		// 데이터가 없는 경우 : 0 반환
+		return lastThreeMonthsStats.isEmpty() ? 0 : totalSpent / 3;
 	}
 }

--- a/src/main/java/com/example/PayAll_BE/service/StatisticsService.java
+++ b/src/main/java/com/example/PayAll_BE/service/StatisticsService.java
@@ -12,9 +12,11 @@ import com.example.PayAll_BE.dto.Statistics.StatisticsDetailResponseDto;
 import com.example.PayAll_BE.dto.Statistics.StatisticsResponseDto;
 import com.example.PayAll_BE.entity.Payment;
 import com.example.PayAll_BE.entity.Statistics;
+import com.example.PayAll_BE.entity.User;
 import com.example.PayAll_BE.entity.enums.StatisticsCategory;
 import com.example.PayAll_BE.repository.PaymentRepository;
 import com.example.PayAll_BE.repository.StatisticsRepository;
+import com.example.PayAll_BE.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,8 +25,12 @@ import lombok.RequiredArgsConstructor;
 public class StatisticsService {
 	private final StatisticsRepository statisticsRepository;
 	private final PaymentRepository paymentRepository;
+	private final UserRepository userRepository;
 
 	public StatisticsResponseDto getStatistics(Long userId, String date) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다."));
 
 		LocalDate startDate = LocalDate.parse(date + "-01");
 		LocalDateTime startDateTime = startDate.atStartOfDay();
@@ -62,8 +68,8 @@ public class StatisticsService {
 		long previousTotalSpent = previousStatistics.stream().mapToLong(Statistics::getStatisticsAmount).sum();
 		long difference = totalSpent - previousTotalSpent;
 
-		// ResponseDTO 생성
 		return StatisticsResponseDto.builder()
+			.name(user.getName())
 			.date(date)
 			.totalSpent(totalSpent)
 			.dateAverage(dateAverage) // 하루 평균 지출
@@ -113,7 +119,7 @@ public class StatisticsService {
 				List<StatisticsDetailResponseDto.TransactionDetail.HistoryDetail> historyDetails = dailyPayments.stream()
 					.map(payment -> new StatisticsDetailResponseDto.TransactionDetail.HistoryDetail(
 						payment.getPaymentPlace(),
-						category.name(), // 태그: 카테고리 이름 사용
+						category.name(), // 태그? 배지? -> 카테고리 이름 사용
 						payment.getPrice(),
 						payment.getPaymentType().name(),
 						payment.getPaymentTime().toLocalTime().toString()

--- a/src/main/java/com/example/PayAll_BE/service/UserService.java
+++ b/src/main/java/com/example/PayAll_BE/service/UserService.java
@@ -1,0 +1,27 @@
+package com.example.PayAll_BE.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.PayAll_BE.dto.UserResponseDto;
+import com.example.PayAll_BE.entity.User;
+import com.example.PayAll_BE.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+	private final UserRepository userRepository;
+
+	public UserResponseDto getUserInfo(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다."));
+
+		return UserResponseDto.builder()
+			.name(user.getName())
+			.authId(user.getAuthId())
+			.phone(user.getPhone())
+			.address(user.getAddress())
+			.build();
+	}
+}


### PR DESCRIPTION
1. 소비목표 조회 api 추가: 3개월 간 평균 지출액, 저번달 목표 지출액
2. 소비목표 등록 api 수정: requestBody: 3개월간 평균 지출액 -> 설정할 목표 금액
3. statistics 분석api에 유저이름 추가
